### PR TITLE
Update for use with Terraform 0.12 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,6 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate_no_variables
-      - id: terraform_docs
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v1.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.2.3
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.14.1
+    rev: v0.16.0
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.4
+    rev: 1.0.5
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
@@ -43,11 +43,11 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.14.0
+    rev: v1.18.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 2a1dbab
+    rev: 1.6.0
     hooks:
       - id: bandit
   - repo: https://github.com/ambv/black
@@ -60,7 +60,7 @@ repos:
       - id: ansible-lint
         # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate_no_variables
@@ -69,6 +69,6 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.16.2
+    rev: 1.18.0
     hooks:
       - id: prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services: docker
 before_install:
   - >
     wget
-    https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip
+    https://releases.hashicorp.com/terraform/0.12.1/terraform_0.12.1_linux_amd64.zip
     -O terraform.zip
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tags = {
 
 ## Terraform Documentation ##
 
-<!-- markdownlint-disable MD003 MD013 MD022 -->
+<!-- markdownlint-disable MD003 MD013 MD022 MD033 -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
@@ -49,7 +49,7 @@ tags = {
 | tags | Tags to apply to all AWS resources created | map | `{}` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- markdownlint-enable MD003 MD013 MD022 -->
+<!-- markdownlint-enable MD003 MD013 MD022 MD033 -->
 
 ## Building the Terraform-based infrastructure ##
 

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "exported_data" {
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = "${local.production_workspace ? format("%s-production", var.assessment_data_s3_bucket) : format("%s-%s", var.assessment_data_s3_bucket, terraform.workspace)}"
+  bucket = local.production_workspace ? format("%s-production", var.assessment_data_s3_bucket) : format("%s-%s", var.assessment_data_s3_bucket, terraform.workspace)
 
   server_side_encryption_configuration {
     rule {
@@ -14,7 +14,12 @@ resource "aws_s3_bucket" "exported_data" {
     }
   }
 
-  tags = "${merge(var.tags, map("Name", "Exported Assessment Data"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Exported Assessment Data"
+    },
+  )
 
   lifecycle {
     prevent_destroy = true

--- a/exported_data_user_write.tf
+++ b/exported_data_user_write.tf
@@ -2,7 +2,7 @@ resource "aws_iam_user" "exported_data_write" {
   # We name the user based on the bucket name (which is based on the
   # terraform workspace name) to avoid name conflicts when deploying to
   # different workspaces
-  name = "${format("%s-write", aws_s3_bucket.exported_data.id)}"
+  name = format("%s-write", aws_s3_bucket.exported_data.id)
 
   lifecycle {
     prevent_destroy = true
@@ -10,7 +10,7 @@ resource "aws_iam_user" "exported_data_write" {
 }
 
 resource "aws_iam_access_key" "exported_data_write" {
-  user = "${aws_iam_user.exported_data_write.name}"
+  user = aws_iam_user.exported_data_write.name
 }
 
 # IAM policy document that that allows write permissions on the export
@@ -31,6 +31,6 @@ data "aws_iam_policy_document" "exported_data_write_doc" {
 
 # The S3 policy for our role
 resource "aws_iam_user_policy" "exported_data_write_policy" {
-  user   = "${aws_iam_user.exported_data_write.name}"
-  policy = "${data.aws_iam_policy_document.exported_data_write_doc.json}"
+  user   = aws_iam_user.exported_data_write.name
+  policy = data.aws_iam_policy_document.exported_data_write_doc.json
 }

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -4,7 +4,11 @@ resource "aws_s3_bucket" "adi_lambda" {
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = "${local.production_workspace ? format("%s-production", var.assessment_data_import_lambda_s3_bucket) : format("%s-%s", var.assessment_data_import_lambda_s3_bucket, terraform.workspace)}"
+  bucket = local.production_workspace ? format("%s-production", var.assessment_data_import_lambda_s3_bucket) : format(
+    "%s-%s",
+    var.assessment_data_import_lambda_s3_bucket,
+    terraform.workspace,
+  )
 
   server_side_encryption_configuration {
     rule {
@@ -14,7 +18,12 @@ resource "aws_s3_bucket" "adi_lambda" {
     }
   }
 
-  tags = "${merge(var.tags, map("Name", "Assessment Data Import Lambda"))}"
+  tags = merge(
+    var.tags,
+    {
+      "Name" = "Assessment Data Import Lambda"
+    },
+  )
 
   lifecycle {
     prevent_destroy = true

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
   # This is a goofy but necessary way to determine if
   # terraform.workspace contains the substring "prod"
-  production_workspace = "${replace(terraform.workspace, "prod", "") != terraform.workspace}"
+  production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 # Configure AWS
 provider "aws" {
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
 # The AWS account ID being used
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,19 +9,19 @@ variable "aws_availability_zone" {
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "Tags to apply to all AWS resources created"
   default     = {}
 }
 
 variable "assessment_data_s3_bucket" {
-  type        = "string"
+  type        = string
   description = "The name of the bucket where the assessment data JSON file will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = ""
 }
 
 variable "assessment_data_import_lambda_s3_bucket" {
-  type        = "string"
+  type        = string
   description = "The name of the bucket where the assessment data import lambda function will be stored.  Note that in production terraform workspaces, the string '-production' will be appended to the bucket name.  In non-production workspaces, '-<workspace_name>' will be appended to the bucket name."
   default     = ""
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
These changes are all from running `terraform 0.12upgrade`.

Note that `terraform-docs` is also removed from `pre-commit`, due to the following incompatibility with terraform 0.12:
```
hookid: terraform_docs

2019/06/06 17:16:36 At 7:12: Unknown token: 7:12 IDENT local.production_workspace
```
It will be re-added later when that issue is corrected.