### PR TITLE
Break out S3 bucket options into standalone resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ No modules.
 | [aws_iam_user_policy.exported_data_write_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_s3_bucket.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_public_access_block.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ No modules.
 | [aws_iam_user_policy.exported_data_write_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_s3_bucket.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_public_access_block.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ tags = {
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.38 |
+| aws | ~> 3.75 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.38 |
+| aws | ~> 3.75 |
 
 ## Modules ##
 
@@ -82,6 +82,8 @@ No modules.
 | [aws_iam_user_policy.exported_data_write_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_s3_bucket.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.adi_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.exported_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.exported_data_write_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -1,7 +1,7 @@
+# This bucket is used to store a JSON file containing all exported
+# assessment data to be imported into the CyHy database.
 resource "aws_s3_bucket" "exported_data" {
-  # This bucket is used to store a JSON file containing all exported
-  # assessment data to be imported into our AWS database.
-  # Note that in production terraform workspaces, the string '-production' is
+  # Note that in production Terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
   bucket = format("%s-%s", var.assessment_data_s3_bucket, local.production_workspace ? "production" : terraform.workspace)

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -6,19 +6,28 @@ resource "aws_s3_bucket" "exported_data" {
   # '-<workspace_name>' is appended to the bucket name.
   bucket = local.production_workspace ? format("%s-production", var.assessment_data_s3_bucket) : format("%s-%s", var.assessment_data_s3_bucket, terraform.workspace)
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
   tags = {
     "Name" = "Exported Assessment Data"
   }
 
   lifecycle {
+    ignore_changes = [
+      # This should be removed when we upgrade the Terraform AWS provider to
+      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # avoid conflicts/unexpected apply results.
+      server_side_encryption_configuration,
+    ]
     prevent_destroy = true
+  }
+}
+
+# Ensure the S3 bucket is encrypted
+resource "aws_s3_bucket_server_side_encryption_configuration" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -42,3 +42,15 @@ resource "aws_s3_bucket_public_access_block" "exported_data" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "exported_data" {
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = local.production_workspace ? format("%s-production", var.assessment_data_s3_bucket) : format("%s-%s", var.assessment_data_s3_bucket, terraform.workspace)
+  bucket = format("%s-%s", var.assessment_data_s3_bucket, local.production_workspace ? "production" : terraform.workspace)
 
   tags = {
     "Name" = "Exported Assessment Data"

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -13,7 +13,7 @@ resource "aws_s3_bucket" "exported_data" {
   lifecycle {
     ignore_changes = [
       # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
     ]

--- a/exported_data_bucket.tf
+++ b/exported_data_bucket.tf
@@ -31,3 +31,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "exported_data" {
     }
   }
 }
+
+# This blocks ANY public access to the bucket or the objects it
+# contains, even if misconfigured to allow public access.
+resource "aws_s3_bucket_public_access_block" "exported_data" {
+  bucket = aws_s3_bucket.exported_data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -35,3 +35,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "adi_lambda" {
     }
   }
 }
+
+# This blocks ANY public access to the bucket or the objects it
+# contains, even if misconfigured to allow public access.
+resource "aws_s3_bucket_public_access_block" "adi_lambda" {
+  bucket = aws_s3_bucket.adi_lambda.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -4,11 +4,7 @@ resource "aws_s3_bucket" "adi_lambda" {
   # Note that in production terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
-  bucket = local.production_workspace ? format("%s-production", var.assessment_data_import_lambda_s3_bucket) : format(
-    "%s-%s",
-    var.assessment_data_import_lambda_s3_bucket,
-    terraform.workspace,
-  )
+  bucket = format("%s-%s", var.assessment_data_import_lambda_s3_bucket, local.production_workspace ? "production" : terraform.workspace)
 
   tags = {
     "Name" = "Assessment Data Import Lambda"

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket" "adi_lambda" {
   lifecycle {
     ignore_changes = [
       # This should be removed when we upgrade the Terraform AWS provider to
-      # v4. It is necessary to use with the back-ported resources in v3.75 to
+      # v4. It is necessary to use with the backported resources in v3.75 to
       # avoid conflicts/unexpected apply results.
       server_side_encryption_configuration,
     ]

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -1,7 +1,8 @@
+# This bucket is used to store the deployment package of the Lambda function
+# that imports assessment data from the exported_data bucket into the CyHy
+# database.
 resource "aws_s3_bucket" "adi_lambda" {
-  # This bucket is used to store the lambda function that imports assessment
-  # data from the exported_data bucket into the CyHy database.
-  # Note that in production terraform workspaces, the string '-production' is
+  # Note that in production Terraform workspaces, the string '-production' is
   # appended to the bucket name.  In non-production workspaces,
   # '-<workspace_name>' is appended to the bucket name.
   bucket = format("%s-%s", var.assessment_data_import_lambda_s3_bucket, local.production_workspace ? "production" : terraform.workspace)

--- a/lambda_bucket.tf
+++ b/lambda_bucket.tf
@@ -46,3 +46,15 @@ resource "aws_s3_bucket_public_access_block" "adi_lambda" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Any objects placed into this bucket should be owned by the bucket
+# owner. This ensures that even if objects are added by a different
+# account, the bucket-owning account retains full control over the
+# objects stored in this bucket.
+resource "aws_s3_bucket_ownership_controls" "adi_lambda" {
+  bucket = aws_s3_bucket.adi_lambda.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  # This is a goofy but necessary way to determine if
-  # terraform.workspace contains the substring "prod"
-  production_workspace = replace(terraform.workspace, "prod", "") != terraform.workspace
+  # Determine if this is a Production workspace by checking
+  # if terraform.workspace begins with "prod"
+  production_workspace = length(regexall("^prod", terraform.workspace)) == 1
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,12 +6,12 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 3.75.0 of the Terraform AWS provider backports the changes to how
+    # AWS S3 resources are structured from the 4.0 release.
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.75"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request breaks out AWS S3 bucket configuration parameters that received back-ported standalone resources with the [3.75.0 release of the Terraform AWS provider](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.75.0). In addition resources have been added to block public access and enforce object ownership for the AWS S3 bucket configurations in this project. Lastly some cleanup was done on bucket name formation and how a production workspace is detected.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In `v3.75.0` of the Terraform AWS provider they back-ported the standalone S3 bucket resources to configure AWS S3 buckets that were introduced in v4 of the provider. This allows you to make changes to your Terraform configurations using v3 of the provider to prepare for the v4 provider. Making this change now helps prepare for updating to the v4 provider (and at this point prepare for the v5 provider).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Applying in both my workspace and the production workspace had the expected changes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
